### PR TITLE
Extra endpoint parameters for filter components

### DIFF
--- a/frontend/src/components/chart-filters/BreakdownFilter.vue
+++ b/frontend/src/components/chart-filters/BreakdownFilter.vue
@@ -11,12 +11,6 @@ export default {
     endpoint() {
       return "/breakdowns/";
     },
-    endpointParams() {
-      return {
-        indicator: this.filterStore.indicator?.code,
-        breakdown_group: this.filterStore.breakdownGroup?.code,
-      };
-    },
     defaultSingleValue() {
       // Default to the first item, as that will likely be the "total"
       return this.items[0]?.id;

--- a/frontend/src/components/chart-filters/BreakdownGroupFilter.vue
+++ b/frontend/src/components/chart-filters/BreakdownGroupFilter.vue
@@ -11,11 +11,6 @@ export default {
     endpoint() {
       return "/breakdown-groups/";
     },
-    endpointParams() {
-      return {
-        indicator: this.filterStore.indicator?.code,
-      };
-    },
     defaultSingleValue() {
       // Default to the first item, as that will likely be the "total"
       return this.items[0]?.id;

--- a/frontend/src/components/chart-filters/CountryFilter.vue
+++ b/frontend/src/components/chart-filters/CountryFilter.vue
@@ -19,11 +19,6 @@ export default {
     endpoint() {
       return "/countries/";
     },
-    endpointParams() {
-      return {
-        indicator: this.filterStore.indicator?.code,
-      };
-    },
     label() {
       return "Country";
     },

--- a/frontend/src/components/chart-filters/IndicatorFilter.vue
+++ b/frontend/src/components/chart-filters/IndicatorFilter.vue
@@ -11,11 +11,6 @@ export default {
     endpoint() {
       return "/indicators/";
     },
-    endpointParams() {
-      return {
-        indicator_group: this.filterStore.indicatorGroup?.code,
-      };
-    },
   },
 };
 </script>

--- a/frontend/src/components/chart-filters/PeriodFilter.vue
+++ b/frontend/src/components/chart-filters/PeriodFilter.vue
@@ -11,11 +11,6 @@ export default {
     endpoint() {
       return "/periods/";
     },
-    endpointParams() {
-      return {
-        indicator: this.filterStore.indicator?.code,
-      };
-    },
     apiData() {
       const periodStart = this.currentChartGroup.period_start ?? -Infinity;
       const periodEnd = this.currentChartGroup.period_end ?? Infinity;

--- a/frontend/src/components/chart-filters/UnitFilter.vue
+++ b/frontend/src/components/chart-filters/UnitFilter.vue
@@ -11,11 +11,6 @@ export default {
     endpoint() {
       return "/units/";
     },
-    endpointParams() {
-      return {
-        indicator: this.filterStore.indicator?.code,
-      };
-    },
   },
 };
 </script>

--- a/frontend/src/components/charts/InteractiveChart.vue
+++ b/frontend/src/components/charts/InteractiveChart.vue
@@ -43,13 +43,29 @@ export default {
       const result = [];
       for (const axis of FILTER_SUFFIXES) {
         const items = this.$refs.chart?.[`filter${axis}Components`] ?? [];
+        const previousParams = [];
 
         for (const item of items) {
           if (!item) {
             continue;
           }
 
-          result.push(this.normalizeFilterComponent(item, axis));
+          const filterComponent = this.normalizeFilterComponent(item, axis);
+
+          // Add extra filter params based on the previous filters; that way
+          // we should never have impossible combinations.
+          filterComponent.attrs.extraParams = [
+            ...(filterComponent.attrs.extraParams ?? []),
+            ...previousParams,
+          ];
+
+          const queryName = filterComponent.component.computed?.queryName?.();
+          const isMultiple = filterComponent.component.computed?.multiple?.();
+          if (queryName && !isMultiple) {
+            previousParams.push(queryName);
+          }
+
+          result.push(filterComponent);
         }
       }
       return result;

--- a/frontend/src/components/charts/column/ColumnStackedCompareBreakdownsWeighted.vue
+++ b/frontend/src/components/charts/column/ColumnStackedCompareBreakdownsWeighted.vue
@@ -19,6 +19,7 @@ export default {
             allInitial: true,
             syncRoute: false,
             class: ["chart-filter-full"],
+            extraParams: ["indicator"],
           },
         },
         IndicatorWithGroupsFilter,

--- a/frontend/src/components/charts/table/TableDebugData.vue
+++ b/frontend/src/components/charts/table/TableDebugData.vue
@@ -4,7 +4,7 @@
     <thead>
       <tr>
         <th>Country</th>
-        <th>{{ unit.display }}</th>
+        <th>{{ unit?.display }}</th>
       </tr>
     </thead>
 


### PR DESCRIPTION
Automatically send drill-down filters to the API instead of having a hardcoded list. 